### PR TITLE
Add email/password registration form to coming soon page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,32 @@
     <h1>We’re planting something big.</h1>
     <p>Solar Roots Co-op — a solar-powered grocery for the people.</p>
     <p><strong>Launching soon.</strong></p>
-    <form id="subscribe">
-      <input type="email" placeholder="Enter your email" required />
-      <button type="submit">Notify Me</button>
+    <form id="registration-form" class="registration-form" novalidate>
+      <div class="field-group">
+        <label for="email">Email address</label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          placeholder="you@example.com"
+          autocomplete="email"
+          required
+        />
+      </div>
+      <div class="field-group">
+        <label for="password">Password</label>
+        <input
+          type="password"
+          id="password"
+          name="password"
+          placeholder="Create a password"
+          autocomplete="new-password"
+          minlength="8"
+          required
+        />
+      </div>
+      <button type="submit">Join the Co-op Waitlist</button>
+      <p id="form-message" class="form-message" role="status" aria-live="polite"></p>
     </form>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,28 @@
-document.getElementById('subscribe').addEventListener('submit', function(e) {
-  e.preventDefault();
-  alert('Thanks for your interest! We’ll keep you posted.');
+const form = document.getElementById('registration-form');
+const messageEl = document.getElementById('form-message');
+
+function setMessage(text, type) {
+  messageEl.textContent = text;
+  messageEl.className = `form-message ${type}`.trim();
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+
+  const email = form.email.value.trim();
+  const password = form.password.value;
+
+  if (!email || !password) {
+    setMessage('Please enter both an email and a password.', 'error');
+    return;
+  }
+
+  if (password.length < 8) {
+    setMessage('Password must be at least 8 characters long.', 'error');
+    form.password.focus();
+    return;
+  }
+
+  setMessage(`Thanks for joining the co-op, ${email}!`, 'success');
+  form.reset();
 });

--- a/style.css
+++ b/style.css
@@ -11,7 +11,8 @@ body {
 }
 
 .container {
-  max-width: 600px;
+  max-width: 480px;
+  width: 100%;
 }
 
 .logo {
@@ -19,14 +20,61 @@ body {
   margin-bottom: 20px;
 }
 
-input, button {
-  padding: 10px;
+.registration-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.field-group {
+  text-align: left;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+input,
+button {
+  width: 100%;
+  padding: 12px;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+input {
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #1f1f1f;
 }
 
 button {
   background: #2E5E4E;
   color: #FFD85B;
   cursor: pointer;
+  font-weight: 700;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover,
+button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+.form-message {
+  min-height: 1.5em;
+  margin: 0;
+  font-weight: 600;
+}
+
+.form-message.success {
+  color: #e7ffad;
+}
+
+.form-message.error {
+  color: #ffdfdf;
 }


### PR DESCRIPTION
## Summary
- replace the notify-me form with an email and password registration experience
- add validation messaging and client-side feedback for missing or short passwords
- refresh the form styling for better layout and hover/focus states

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f375035a488332a897f3ea809a8ec4