### PR TITLE
Add subscription Pages Function with D1 persistence

### DIFF
--- a/functions/api/subscribe.ts
+++ b/functions/api/subscribe.ts
@@ -1,0 +1,239 @@
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(): Promise<T | null>;
+  run<T = unknown>(): Promise<T>;
+}
+
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+interface Env {
+  DB: D1Database;
+  MAIL_FROM_EMAIL?: string;
+  MAIL_FROM_NAME?: string;
+  MAILCHANNELS_DOMAIN?: string;
+  MAILCHANNELS_SUBDOMAIN?: string;
+  SENDGRID_API_KEY?: string;
+  SENDGRID_FROM_EMAIL?: string;
+  SENDGRID_FROM_NAME?: string;
+  SITE_BASE_URL?: string;
+}
+
+interface SubscriptionRecord {
+  email: string;
+  confirmed: number;
+  confirmation_token?: string;
+}
+
+interface PagesFunctionContext {
+  request: Request;
+  env: Env;
+  waitUntil(promise: Promise<unknown>): void;
+  log: (...args: unknown[]) => void;
+}
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+export const onRequestPost = async (ctx: PagesFunctionContext): Promise<Response> => {
+  const { request, env, log } = ctx;
+  try {
+    const payload = await parseJson(request, log);
+    if (!payload) {
+      return jsonResponse({ success: false, error: 'Invalid JSON body.' }, 400);
+    }
+
+    const { email } = payload;
+    if (typeof email !== 'string' || !isValidEmail(email)) {
+      return jsonResponse({ success: false, error: 'A valid email address is required.' }, 400);
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      return jsonResponse({ success: false, error: 'A valid email address is required.' }, 400);
+    }
+
+    await ensureSchema(env.DB);
+
+    const existing = await env.DB
+      .prepare('SELECT email, confirmed, confirmation_token FROM subscriptions WHERE email = ?')
+      .bind(normalizedEmail)
+      .first<SubscriptionRecord>();
+
+    const now = new Date().toISOString();
+    let token = crypto.randomUUID();
+
+    if (existing) {
+      if (existing.confirmed) {
+        return jsonResponse({ success: true, message: 'Email is already confirmed.' }, 200);
+      }
+
+      token = existing.confirmation_token ?? token;
+      await env.DB
+        .prepare(
+          'UPDATE subscriptions SET confirmation_token = ?, token_created_at = ?, updated_at = ? WHERE email = ?'
+        )
+        .bind(token, now, now, normalizedEmail)
+        .run();
+    } else {
+      await env.DB
+        .prepare(
+          'INSERT INTO subscriptions (email, created_at, confirmed, confirmation_token, token_created_at) VALUES (?, ?, 0, ?, ?)'
+        )
+        .bind(normalizedEmail, now, token, now)
+        .run();
+    }
+
+    const confirmationLink = buildConfirmationLink(request.url, env.SITE_BASE_URL, normalizedEmail, token);
+
+    ctx.waitUntil(
+      sendConfirmationEmail(env, normalizedEmail, confirmationLink, log).catch((error) => {
+        log('Failed to send confirmation email', error);
+      })
+    );
+
+    return jsonResponse(
+      {
+        success: true,
+        message: 'Confirmation email sent. Please check your inbox.',
+      },
+      202
+    );
+  } catch (error) {
+    log('Subscription handler failed', error);
+    return jsonResponse({ success: false, error: 'Internal Server Error' }, 500);
+  }
+};
+
+async function parseJson(request: Request, log: (...args: unknown[]) => void): Promise<Record<string, unknown> | null> {
+  try {
+    const data = (await request.json()) as unknown;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return null;
+    }
+
+    return data as Record<string, unknown>;
+  } catch (error) {
+    log('Failed to parse JSON body', error);
+    return null;
+  }
+}
+
+function isValidEmail(email: string): boolean {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailPattern.test(email);
+}
+
+async function ensureSchema(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      'CREATE TABLE IF NOT EXISTS subscriptions (email TEXT PRIMARY KEY, created_at TEXT NOT NULL, updated_at TEXT, confirmed INTEGER NOT NULL DEFAULT 0, confirmation_token TEXT, token_created_at TEXT)'
+    )
+    .run();
+}
+
+function buildConfirmationLink(requestUrl: string, configuredBaseUrl: string | undefined, email: string, token: string): string {
+  const base = configuredBaseUrl ?? new URL(requestUrl).origin;
+  const url = new URL('/confirm', base);
+  url.searchParams.set('token', token);
+  url.searchParams.set('email', email);
+  return url.toString();
+}
+
+async function sendConfirmationEmail(env: Env, recipient: string, link: string, log: (...args: unknown[]) => void): Promise<void> {
+  if (env.SENDGRID_API_KEY) {
+    await sendWithSendGrid(env, recipient, link, log);
+  } else {
+    await sendWithMailChannels(env, recipient, link, log);
+  }
+}
+
+async function sendWithMailChannels(env: Env, recipient: string, link: string, log: (...args: unknown[]) => void): Promise<void> {
+  const fromEmail = env.MAIL_FROM_EMAIL ?? 'noreply@example.com';
+  const fromName = env.MAIL_FROM_NAME ?? 'Solar Roots';
+
+  const personalization: Record<string, unknown> = {
+    to: [{ email: recipient }],
+  };
+
+  if (env.MAILCHANNELS_DOMAIN) {
+    personalization['dkim_domain'] = env.MAILCHANNELS_DOMAIN;
+  }
+
+  if (env.MAILCHANNELS_SUBDOMAIN) {
+    personalization['dkim_selector'] = env.MAILCHANNELS_SUBDOMAIN;
+  }
+
+  const response = await fetch('https://api.mailchannels.net/tx/v1/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [
+        personalization,
+      ],
+      from: { email: fromEmail, name: fromName },
+      subject: 'Confirm your Solar Roots subscription',
+      content: [
+        {
+          type: 'text/plain',
+          value: `Thanks for subscribing to Solar Roots! Confirm your email by visiting: ${link}`,
+        },
+        {
+          type: 'text/html',
+          value: `<p>Thanks for subscribing to Solar Roots!</p><p><a href="${link}">Click here to confirm your email address</a>.</p>`,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('MailChannels error', response.status, errorText);
+    throw new Error(`MailChannels request failed with status ${response.status}`);
+  }
+}
+
+async function sendWithSendGrid(env: Env, recipient: string, link: string, log: (...args: unknown[]) => void): Promise<void> {
+  const fromEmail = env.SENDGRID_FROM_EMAIL ?? env.MAIL_FROM_EMAIL ?? 'noreply@example.com';
+  const fromName = env.SENDGRID_FROM_NAME ?? env.MAIL_FROM_NAME ?? 'Solar Roots';
+
+  const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${env.SENDGRID_API_KEY}`,
+    },
+    body: JSON.stringify({
+      personalizations: [
+        {
+          to: [{ email: recipient }],
+        },
+      ],
+      from: { email: fromEmail, name: fromName },
+      subject: 'Confirm your Solar Roots subscription',
+      content: [
+        {
+          type: 'text/plain',
+          value: `Thanks for subscribing to Solar Roots! Confirm your email by visiting: ${link}`,
+        },
+        {
+          type: 'text/html',
+          value: `<p>Thanks for subscribing to Solar Roots!</p><p><a href="${link}">Click here to confirm your email address</a>.</p>`,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('SendGrid error', response.status, errorText);
+    throw new Error(`SendGrid request failed with status ${response.status}`);
+  }
+}
+
+function jsonResponse(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages Function at `functions/api/subscribe.ts` that validates incoming JSON requests and returns structured errors
- persist subscription records in D1 with confirmation tokens and timestamps so repeat requests update existing rows
- enqueue confirmation email delivery via MailChannels or SendGrid and log delivery failures

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f411588db08332a84a822cf032785d