### PR TITLE
Bind D1 database in Wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,8 @@ binding = "ASSETS"
 
 [vars]
 SITE_BASE_URL = "https://solarroots.example.com"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "solarroots"
+database_id = "00000000-0000-0000-0000-000000000000" # replace with your D1 database UUID


### PR DESCRIPTION
## Summary
- add a D1 database binding to the Wrangler configuration so the Worker can access its datastore

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fbe572a174833288d86fad8c788e71