### PR TITLE
Add profile signup page and link from landing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -123,6 +123,24 @@
       color: rgba(255, 255, 255, 0.75);
     }
 
+    .profile-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+      font-weight: 600;
+      color: #ffd85b;
+      text-decoration: none;
+      transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .profile-link:hover,
+    .profile-link:focus-visible {
+      transform: translateY(-1px);
+      opacity: 0.85;
+    }
+
     #form-message {
       min-height: 1.5rem;
       font-weight: 600;
@@ -161,6 +179,10 @@
       <p class="note">We respect your inbox. Expect only the important updates.</p>
       <p id="form-message" role="status" aria-live="polite"></p>
     </form>
+    <a class="profile-link" href="/signup.html" aria-label="Create your Solar Roots member profile">
+      Create your Solar Roots profile
+      <span aria-hidden="true">→</span>
+    </a>
   </main>
   <script src="script.js"></script>
 </body>

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Create Your Solar Roots Profile</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background-color: #2e5e4e;
+      color: #ffffff;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem;
+      background: linear-gradient(to bottom right, rgba(46, 94, 78, 0.95), rgba(255, 216, 91, 0.85));
+      color: #ffffff;
+    }
+
+    main {
+      width: min(600px, 100%);
+      display: grid;
+      gap: 2rem;
+      background: rgba(0, 0, 0, 0.28);
+      padding: 2.5rem 2rem;
+      border-radius: 20px;
+      box-shadow: 0 25px 40px -20px rgba(0, 0, 0, 0.4);
+    }
+
+    .logo {
+      width: fit-content;
+      padding: 0.75rem 1.75rem;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.25);
+      font-weight: 700;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      justify-self: center;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 3vw + 1rem, 3rem);
+      text-align: center;
+      line-height: 1.2;
+    }
+
+    p.lede {
+      font-size: 1.05rem;
+      line-height: 1.6;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    form {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .field {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    label {
+      font-size: 0.8rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.75);
+    }
+
+    input,
+    textarea {
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      border: none;
+      background: rgba(255, 255, 255, 0.9);
+      color: #1f1f1f;
+      font-size: 1rem;
+      outline: none;
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
+      resize: vertical;
+      min-height: 3rem;
+    }
+
+    textarea {
+      min-height: 6rem;
+    }
+
+    input:focus,
+    textarea:focus {
+      box-shadow: 0 0 0 3px rgba(255, 216, 91, 0.6);
+      transform: translateY(-1px);
+    }
+
+    button[type="submit"] {
+      padding: 0.9rem 1.5rem;
+      border-radius: 12px;
+      border: none;
+      font-size: 1rem;
+      font-weight: 700;
+      cursor: pointer;
+      background: #2e5e4e;
+      color: #ffd85b;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button[type="submit"]:hover,
+    button[type="submit"]:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px -14px rgba(0, 0, 0, 0.55);
+    }
+
+    #profile-message {
+      min-height: 1.5rem;
+      font-weight: 600;
+      text-align: center;
+    }
+
+    #profile-message.success {
+      color: #e7ffad;
+    }
+
+    #profile-message.error {
+      color: #ffdfdf;
+    }
+
+    .nav-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      font-weight: 600;
+    }
+
+    .nav-links a {
+      color: #ffd85b;
+      text-decoration: none;
+      transition: opacity 0.2s ease;
+    }
+
+    .nav-links a:hover,
+    .nav-links a:focus-visible {
+      opacity: 0.8;
+    }
+
+    @media (max-width: 520px) {
+      body {
+        padding: 2.5rem 1.25rem;
+      }
+
+      main {
+        padding: 2rem 1.5rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="logo">Solar Roots</div>
+    <h1>Create your Solar Roots profile</h1>
+    <p class="lede">Tell us a little about yourself so we can tailor the Solar Roots experience for you once we launch.</p>
+
+    <form id="profile-form" novalidate>
+      <div class="field">
+        <label for="profile-email">Email</label>
+        <input type="email" id="profile-email" name="email" placeholder="you@example.com" autocomplete="email" required>
+      </div>
+      <div class="field">
+        <label for="profile-name">Name</label>
+        <input type="text" id="profile-name" name="name" placeholder="Your full name" autocomplete="name" required>
+      </div>
+      <div class="field">
+        <label for="profile-bio">Bio</label>
+        <textarea id="profile-bio" name="bio" placeholder="Share your interests, skills, or anything you'd like us to know." required></textarea>
+      </div>
+      <button type="submit">Save my profile</button>
+      <p id="profile-message" role="status" aria-live="polite"></p>
+    </form>
+
+    <nav class="nav-links" aria-label="Secondary">
+      <a href="/">Back to landing page</a>
+    </nav>
+  </main>
+  <script src="signup.js" type="module"></script>
+</body>
+</html>

--- a/public/signup.js
+++ b/public/signup.js
@@ -1,0 +1,85 @@
+const form = document.getElementById('profile-form');
+const message = document.getElementById('profile-message');
+const submitButton = form?.querySelector('button[type="submit"]');
+
+function setMessage(text, status) {
+  if (!message) return;
+  message.textContent = text;
+  message.classList.remove('success', 'error');
+  if (status) {
+    message.classList.add(status);
+  }
+}
+
+function setSubmitting(isSubmitting) {
+  if (!submitButton) return;
+  submitButton.disabled = isSubmitting;
+  submitButton.textContent = isSubmitting ? 'Saving…' : 'Save my profile';
+}
+
+function validateInputs(email, name, bio) {
+  if (!email) {
+    setMessage('Please provide an email address.', 'error');
+    return false;
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(email)) {
+    setMessage('That email doesn’t look quite right.', 'error');
+    return false;
+  }
+
+  if (!name) {
+    setMessage('Share your name so we know what to call you.', 'error');
+    return false;
+  }
+
+  if (!bio) {
+    setMessage('A short bio helps us learn about you. Please add a few words.', 'error');
+    return false;
+  }
+
+  return true;
+}
+
+if (form && message) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const email = (formData.get('email') ?? '').toString().trim().toLowerCase();
+    const name = (formData.get('name') ?? '').toString().trim();
+    const bio = (formData.get('bio') ?? '').toString().trim();
+
+    if (!validateInputs(email, name, bio)) {
+      return;
+    }
+
+    setSubmitting(true);
+    setMessage('Saving your profile…');
+
+    try {
+      const response = await fetch('/api/profile', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, name, bio }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok || !data.success) {
+        const errorMessage = data?.error ?? 'We could not save your profile. Please try again.';
+        setMessage(errorMessage, 'error');
+        return;
+      }
+
+      setMessage(data.message ?? 'Profile saved successfully!', 'success');
+      form.reset();
+    } catch (error) {
+      console.error('Profile request failed', error);
+      setMessage('Something went wrong on our end. Please try again shortly.', 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated profile signup page with styling consistent with the landing experience
- wire up a client-side script that saves profile data through the existing API
- link the landing page waitlist section to the new profile signup flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fc0b40f4448332b81581ef2f530f20