### PR TITLE
Update landing page timeline to 2026 launch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -453,15 +453,15 @@
       <h2 class="section-title" id="timeline-heading">Our launch plan</h2>
       <div class="timeline" role="list">
         <article class="timeline-step" role="listitem">
-          <h4>Spring 2024 · Site build-out</h4>
+          <h4>Spring 2026 · Site build-out</h4>
           <p>Install solar arrays, energy storage, and vertical farms across our flagship warehouse.</p>
         </article>
         <article class="timeline-step" role="listitem">
-          <h4>Summer 2024 · Member beta</h4>
+          <h4>Summer 2026 · Member beta</h4>
           <p>Founding members test the co-op, refine the offerings, and grow our local supplier network.</p>
         </article>
         <article class="timeline-step" role="listitem">
-          <h4>Fall 2024 · Grand opening</h4>
+          <h4>Fall 2026 · Grand opening</h4>
           <p>Doors open to the public with a celebratory market, live demos, and community power tours.</p>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- update the public timeline so all milestones begin in spring 2026 and follow through fall 2026

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc28f2540c83328bbe4bdfc4f73559