### PR TITLE
Add interactive Solar Roots dashboard POC

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -69,6 +69,9 @@ if (form && message) {
 
       setMessage(data.message ?? 'Access granted. Redirecting to the admin dashboard…', 'success');
       form.reset();
+      setTimeout(() => {
+        window.location.href = '/dashboard.html';
+      }, 900);
     } catch (error) {
       console.error('Admin login request failed', error);
       setMessage('Something went wrong on our end. Please try again shortly.', 'error');

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Solar Roots Dashboard | Circular Energy Economy Snapshot</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background-color: #1b322b;
+      color: #ffffff;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: radial-gradient(circle at 15% 20%, rgba(255, 216, 91, 0.32), transparent 55%),
+        linear-gradient(180deg, #2e5e4e, #1b322b 58%, #13211c 100%);
+      color: #ffffff;
+    }
+
+    header {
+      padding: clamp(1.25rem, 4vw, 2rem) clamp(1.75rem, 6vw, 4rem) 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+
+    .brand-mark {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      background: rgba(255, 216, 91, 0.18);
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #ffd85b;
+    }
+
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      font-weight: 600;
+    }
+
+    nav a {
+      text-decoration: none;
+      color: rgba(255, 255, 255, 0.82);
+      background: rgba(0, 0, 0, 0.18);
+      padding: 0.55rem 1.2rem;
+      border-radius: 999px;
+      font-size: 0.82rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      transition: transform 0.2s ease, background 0.2s ease, opacity 0.2s ease;
+    }
+
+    nav a:hover,
+    nav a:focus-visible {
+      transform: translateY(-1px);
+      background: rgba(0, 0, 0, 0.28);
+    }
+
+    nav a[aria-current="page"] {
+      background: rgba(255, 216, 91, 0.28);
+      color: #ffd85b;
+    }
+
+    main {
+      flex: 1;
+      display: grid;
+      gap: clamp(2rem, 4vw, 3.5rem);
+      padding: clamp(2rem, 6vw, 4rem) clamp(1.75rem, 6vw, 4rem) clamp(3rem, 7vw, 4.5rem);
+    }
+
+    .intro {
+      display: grid;
+      gap: 1.25rem;
+      background: rgba(0, 0, 0, 0.28);
+      border-radius: 28px;
+      padding: clamp(2rem, 5vw, 3.5rem);
+      box-shadow: 0 32px 56px -36px rgba(0, 0, 0, 0.7);
+    }
+
+    .intro h1 {
+      font-size: clamp(2.35rem, 5vw, 3.4rem);
+      line-height: 1.12;
+    }
+
+    .intro p {
+      font-size: clamp(1rem, 2vw, 1.2rem);
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    .controls {
+      display: grid;
+      gap: 1.5rem;
+      background: rgba(0, 0, 0, 0.32);
+      border-radius: 24px;
+      padding: clamp(1.75rem, 4vw, 3rem);
+      box-shadow: 0 28px 52px -34px rgba(0, 0, 0, 0.65);
+    }
+
+    .controls-header {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .controls-header h2 {
+      font-size: clamp(1.5rem, 3.5vw, 2.1rem);
+    }
+
+    .controls-header p {
+      color: rgba(255, 255, 255, 0.8);
+      line-height: 1.6;
+      max-width: 720px;
+    }
+
+    .slider-group {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .slider-label {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-size: 0.78rem;
+      color: rgba(255, 255, 255, 0.76);
+    }
+
+    .slider-output {
+      font-size: 1rem;
+      letter-spacing: 0.04em;
+      color: #ffd85b;
+    }
+
+    input[type="range"] {
+      width: 100%;
+      -webkit-appearance: none;
+      appearance: none;
+      height: 10px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.25);
+      outline: none;
+    }
+
+    input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffd85b;
+      border: 2px solid #2e5e4e;
+      cursor: pointer;
+      transition: transform 0.2s ease;
+    }
+
+    input[type="range"]::-webkit-slider-thumb:hover {
+      transform: scale(1.1);
+    }
+
+    input[type="range"]::-moz-range-thumb {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffd85b;
+      border: 2px solid #2e5e4e;
+      cursor: pointer;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: clamp(1.5rem, 3vw, 2.25rem);
+    }
+
+    .metric-card {
+      background: rgba(0, 0, 0, 0.35);
+      border-radius: 22px;
+      padding: clamp(1.5rem, 3vw, 2.25rem);
+      display: grid;
+      gap: 0.75rem;
+      box-shadow: 0 24px 45px -32px rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 216, 91, 0.18);
+    }
+
+    .metric-card h3 {
+      font-size: 0.95rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.72);
+    }
+
+    .metric-card .value {
+      font-size: clamp(1.75rem, 4vw, 2.6rem);
+      font-weight: 700;
+      color: #ffd85b;
+    }
+
+    .metric-card p {
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.78);
+    }
+
+    .impact-layout {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: stretch;
+    }
+
+    .impact-story {
+      background: rgba(0, 0, 0, 0.32);
+      border-radius: 24px;
+      padding: clamp(1.75rem, 4vw, 2.75rem);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .impact-story h2 {
+      font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+    }
+
+    .impact-story p {
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.82);
+    }
+
+    .fund-breakdown {
+      background: rgba(0, 0, 0, 0.32);
+      border-radius: 24px;
+      padding: clamp(1.75rem, 4vw, 2.75rem);
+      display: grid;
+      gap: 1rem;
+    }
+
+    .fund-breakdown h3 {
+      font-size: 1.05rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.75);
+    }
+
+    .fund-rows {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .fund-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      background: rgba(255, 216, 91, 0.12);
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+    }
+
+    .fund-row span {
+      font-weight: 600;
+      letter-spacing: 0.05em;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: rgba(0, 0, 0, 0.28);
+      border-radius: 18px;
+      overflow: hidden;
+    }
+
+    thead {
+      background: rgba(255, 216, 91, 0.18);
+      color: #ffd85b;
+    }
+
+    th,
+    td {
+      padding: 1rem 1.25rem;
+      text-align: left;
+      font-size: 0.95rem;
+    }
+
+    tbody tr:nth-child(even) {
+      background: rgba(0, 0, 0, 0.24);
+    }
+
+    tbody tr + tr {
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    footer {
+      padding: 2.5rem 5vw 3.5rem;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.68);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      nav {
+        width: 100%;
+        justify-content: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a class="brand" href="/" aria-label="Solar Roots landing page">
+      <span class="brand-mark">SR</span>
+      <span>Solar Roots</span>
+    </a>
+    <nav aria-label="Primary">
+      <a href="/">Landing</a>
+      <a href="/dashboard.html" aria-current="page">Dashboard</a>
+      <a href="/learn-more.html">Learn</a>
+      <a href="/signup.html">Join</a>
+      <a href="/admin.html">Admin</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="intro" aria-labelledby="dashboard-heading">
+      <div>
+        <p class="eyebrow" style="letter-spacing: 0.32em; text-transform: uppercase; font-weight: 600; color: rgba(255, 255, 255, 0.6);">Minimum POC · The Solar Roots Dashboard</p>
+        <h1 id="dashboard-heading">Visualize a circular, community-owned energy loop in one neighborhood.</h1>
+      </div>
+      <p>
+        This prototype translates mock solar production, hempcrete retrofits, and carbon credit revenue into tangible reinvestment for a cooperative grocery fund. Adjust the inputs to see how welcoming more member-owners and panels accelerates neighborhood resilience.
+      </p>
+    </section>
+
+    <section class="controls" aria-labelledby="what-if-heading">
+      <div class="controls-header">
+        <h2 id="what-if-heading">"What if" scenario builder</h2>
+        <p>
+          Move the sliders to explore how scaling a single 8-block zone changes energy savings, low-carbon building material usage, and cooperative dollars flowing back into staple foods and micro-grants.
+        </p>
+      </div>
+      <div class="slider-group">
+        <div class="slider-label">
+          <span>Member-owners participating</span>
+          <span class="slider-output" id="members-output" aria-live="polite">0</span>
+        </div>
+        <input type="range" min="40" max="320" value="120" step="5" id="members-slider" aria-describedby="members-note">
+        <p id="members-note" style="font-size: 0.85rem; color: rgba(255, 255, 255, 0.72);">
+          Baseline scenario models 120 founding members stewarding rooftop panels across a 1-mile radius.
+        </p>
+      </div>
+      <div class="slider-group">
+        <div class="slider-label">
+          <span>Rooftop solar panels deployed</span>
+          <span class="slider-output" id="panels-output" aria-live="polite">0</span>
+        </div>
+        <input type="range" min="80" max="480" value="220" step="5" id="panels-slider" aria-describedby="panels-note">
+        <p id="panels-note" style="font-size: 0.85rem; color: rgba(255, 255, 255, 0.72);">
+          Includes school, church, and apartment rooftops with shared energy storage on the block.
+        </p>
+      </div>
+    </section>
+
+    <section class="metrics-grid" aria-label="Impact metrics">
+      <article class="metric-card">
+        <h3>Annual energy savings</h3>
+        <p class="value" id="energy-savings">—</p>
+        <p id="energy-copy">Clean energy removes utility burdens for neighbors and anchors the cooperative grocery freezers.</p>
+      </article>
+      <article class="metric-card">
+        <h3>Hempcrete retrofits</h3>
+        <p class="value" id="hempcrete-use">—</p>
+        <p id="hempcrete-copy">Partner crews pour hempcrete panels to insulate multifamily homes and the market storefront.</p>
+      </article>
+      <article class="metric-card">
+        <h3>Carbon credits earned</h3>
+        <p class="value" id="carbon-credits">—</p>
+        <p id="carbon-copy">Selling neighborhood offsets keeps capital circulating locally while shrinking emissions.</p>
+      </article>
+      <article class="metric-card">
+        <h3>Co-op reinvestment</h3>
+        <p class="value" id="reinvestment">—</p>
+        <p id="reinvestment-copy">Fresh produce stipends, community fridge restocks, and a solidarity grocery dividend grow together.</p>
+      </article>
+    </section>
+
+    <section class="impact-layout">
+      <div class="impact-story">
+        <h2>How the dollars flow</h2>
+        <p>
+          Solar savings slash resident utility bills and fund hempcrete retrofits that further reduce load. Carbon credit revenue is pooled with member dues, fueling a reinvestment flywheel that keeps essentials stocked and creates local green jobs.
+        </p>
+        <p>
+          The scenario builder compares your selections against our baseline cooperative pilot. Watch the grocery fund, resilience grants, and neighborhood dividend respond in real-time as more rooftops join the collective.
+        </p>
+      </div>
+      <aside class="fund-breakdown" aria-labelledby="fund-breakdown-heading">
+        <h3 id="fund-breakdown-heading">Community grocery fund allocation</h3>
+        <div class="fund-rows" id="fund-rows">
+          <div class="fund-row">
+            <span>Fresh food stipends</span>
+            <span id="stipends-amount">—</span>
+          </div>
+          <div class="fund-row">
+            <span>Micro-grants &amp; training</span>
+            <span id="grants-amount">—</span>
+          </div>
+          <div class="fund-row">
+            <span>Neighborhood dividend</span>
+            <span id="dividend-amount">—</span>
+          </div>
+        </div>
+        <p style="font-size: 0.88rem; color: rgba(255, 255, 255, 0.7);">
+          Assumes 65% of the reinvestment fund supports staple groceries, 20% seeds new green entrepreneurs, and 15% thanks every household with a seasonal dividend.
+        </p>
+      </aside>
+    </section>
+
+    <section aria-labelledby="baseline-table-heading">
+      <h2 id="baseline-table-heading" style="font-size: clamp(1.4rem, 3vw, 2rem); margin-bottom: 1.25rem;">Scenario vs. baseline snapshot</h2>
+      <table aria-describedby="baseline-note">
+        <thead>
+          <tr>
+            <th scope="col">Indicator</th>
+            <th scope="col">Baseline pilot</th>
+            <th scope="col">Your scenario</th>
+            <th scope="col">Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Annual energy (kWh)</th>
+            <td id="baseline-energy">—</td>
+            <td id="scenario-energy">—</td>
+            <td id="delta-energy">—</td>
+          </tr>
+          <tr>
+            <th scope="row">Hempcrete bales</th>
+            <td id="baseline-hempcrete">—</td>
+            <td id="scenario-hempcrete">—</td>
+            <td id="delta-hempcrete">—</td>
+          </tr>
+          <tr>
+            <th scope="row">Carbon credits</th>
+            <td id="baseline-carbon">—</td>
+            <td id="scenario-carbon">—</td>
+            <td id="delta-carbon">—</td>
+          </tr>
+          <tr>
+            <th scope="row">Grocery fund ($)</th>
+            <td id="baseline-reinvestment">—</td>
+            <td id="scenario-reinvestment">—</td>
+            <td id="delta-reinvestment">—</td>
+          </tr>
+        </tbody>
+      </table>
+      <p id="baseline-note" style="margin-top: 1rem; font-size: 0.85rem; color: rgba(255, 255, 255, 0.7);">
+        Baseline is anchored to an 8-block pilot with 100 member-owners and 180 panels feeding a 150 kW shared battery.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    Built for the Solar Roots cooperative vision · Mock data only · Last updated <span id="dashboard-year"></span>
+  </footer>
+
+  <script src="dashboard.js" type="module"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,198 @@
+const membersSlider = document.getElementById('members-slider');
+const panelsSlider = document.getElementById('panels-slider');
+const membersOutput = document.getElementById('members-output');
+const panelsOutput = document.getElementById('panels-output');
+const energySavingsTarget = document.getElementById('energy-savings');
+const hempcreteTarget = document.getElementById('hempcrete-use');
+const carbonTarget = document.getElementById('carbon-credits');
+const reinvestmentTarget = document.getElementById('reinvestment');
+const stipendsTarget = document.getElementById('stipends-amount');
+const grantsTarget = document.getElementById('grants-amount');
+const dividendTarget = document.getElementById('dividend-amount');
+const baselineEnergyTarget = document.getElementById('baseline-energy');
+const scenarioEnergyTarget = document.getElementById('scenario-energy');
+const deltaEnergyTarget = document.getElementById('delta-energy');
+const baselineHempcreteTarget = document.getElementById('baseline-hempcrete');
+const scenarioHempcreteTarget = document.getElementById('scenario-hempcrete');
+const deltaHempcreteTarget = document.getElementById('delta-hempcrete');
+const baselineCarbonTarget = document.getElementById('baseline-carbon');
+const scenarioCarbonTarget = document.getElementById('scenario-carbon');
+const deltaCarbonTarget = document.getElementById('delta-carbon');
+const baselineReinvestmentTarget = document.getElementById('baseline-reinvestment');
+const scenarioReinvestmentTarget = document.getElementById('scenario-reinvestment');
+const deltaReinvestmentTarget = document.getElementById('delta-reinvestment');
+const dashboardYear = document.getElementById('dashboard-year');
+
+const BASELINE = {
+  members: 100,
+  panels: 180,
+};
+
+const CONSTANTS = {
+  energyPerPanelKwh: 4200, // annual production per panel
+  savingsPerKwh: 0.18, // retail value of each kWh displaced ($)
+  hempcretePerMember: 1.4, // bales dedicated to each member household retrofit
+  hempcretePerPanel: 0.15, // supplemental hempcrete for battery and market envelope
+  carbonCreditsPerPanel: 0.85, // metric tons avoided per panel per year
+  carbonCreditValue: 42, // average $ per carbon credit sold in a neighborhood bundle
+  duesPerMember: 120, // annual cooperative dues per member household ($)
+  reinvestmentShareFromDues: 0.7,
+  reinvestmentShareFromEnergy: 0.35,
+  reinvestmentShareFromCredits: 0.5,
+  stipendShare: 0.65,
+  grantsShare: 0.2,
+  dividendShare: 0.15,
+};
+
+function toNumber(input) {
+  if (!input) return 0;
+  const value = Number.parseInt(input.value, 10);
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return value;
+}
+
+function formatNumber(value) {
+  return Math.round(value).toLocaleString();
+}
+
+function formatDecimal(value, fractionDigits = 1) {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
+function formatCurrency(value) {
+  return `$${value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function calculateScenario({ members, panels }) {
+  const energyKwh = panels * CONSTANTS.energyPerPanelKwh;
+  const energyValue = energyKwh * CONSTANTS.savingsPerKwh;
+
+  const hempcreteBales = members * CONSTANTS.hempcretePerMember + panels * CONSTANTS.hempcretePerPanel;
+
+  const carbonCredits = panels * CONSTANTS.carbonCreditsPerPanel;
+  const carbonValue = carbonCredits * CONSTANTS.carbonCreditValue;
+
+  const reinvestmentFromDues = members * CONSTANTS.duesPerMember * CONSTANTS.reinvestmentShareFromDues;
+  const reinvestmentFromEnergy = energyValue * CONSTANTS.reinvestmentShareFromEnergy;
+  const reinvestmentFromCredits = carbonValue * CONSTANTS.reinvestmentShareFromCredits;
+  const totalReinvestment = reinvestmentFromDues + reinvestmentFromEnergy + reinvestmentFromCredits;
+
+  return {
+    members,
+    panels,
+    energyKwh,
+    energyValue,
+    hempcreteBales,
+    carbonCredits,
+    carbonValue,
+    totalReinvestment,
+  };
+}
+
+function renderScenario() {
+  if (
+    !membersSlider ||
+    !panelsSlider ||
+    !membersOutput ||
+    !panelsOutput ||
+    !energySavingsTarget ||
+    !hempcreteTarget ||
+    !carbonTarget ||
+    !reinvestmentTarget ||
+    !stipendsTarget ||
+    !grantsTarget ||
+    !dividendTarget ||
+    !baselineEnergyTarget ||
+    !scenarioEnergyTarget ||
+    !deltaEnergyTarget ||
+    !baselineHempcreteTarget ||
+    !scenarioHempcreteTarget ||
+    !deltaHempcreteTarget ||
+    !baselineCarbonTarget ||
+    !scenarioCarbonTarget ||
+    !deltaCarbonTarget ||
+    !baselineReinvestmentTarget ||
+    !scenarioReinvestmentTarget ||
+    !deltaReinvestmentTarget
+  ) {
+    return;
+  }
+
+  const current = {
+    members: toNumber(membersSlider),
+    panels: toNumber(panelsSlider),
+  };
+
+  const scenario = calculateScenario(current);
+  const baseline = calculateScenario(BASELINE);
+
+  membersOutput.textContent = `${scenario.members.toLocaleString()} member-owners`;
+  panelsOutput.textContent = `${scenario.panels.toLocaleString()} panels`;
+
+  energySavingsTarget.textContent = `${formatNumber(scenario.energyKwh)} kWh`;
+  hempcreteTarget.textContent = `${formatNumber(scenario.hempcreteBales)} bales`;
+  carbonTarget.textContent = `${formatDecimal(scenario.carbonCredits, 1)} credits`;
+  reinvestmentTarget.textContent = formatCurrency(scenario.totalReinvestment);
+
+  const stipends = scenario.totalReinvestment * CONSTANTS.stipendShare;
+  const grants = scenario.totalReinvestment * CONSTANTS.grantsShare;
+  const dividend = scenario.totalReinvestment * CONSTANTS.dividendShare;
+
+  stipendsTarget.textContent = formatCurrency(stipends);
+  grantsTarget.textContent = formatCurrency(grants);
+  dividendTarget.textContent = formatCurrency(dividend);
+
+  baselineEnergyTarget.textContent = `${formatNumber(baseline.energyKwh)} kWh`;
+  scenarioEnergyTarget.textContent = `${formatNumber(scenario.energyKwh)} kWh`;
+  deltaEnergyTarget.textContent = deltaLabel(scenario.energyKwh - baseline.energyKwh, 'kWh');
+
+  baselineHempcreteTarget.textContent = `${formatNumber(baseline.hempcreteBales)} bales`;
+  scenarioHempcreteTarget.textContent = `${formatNumber(scenario.hempcreteBales)} bales`;
+  deltaHempcreteTarget.textContent = deltaLabel(scenario.hempcreteBales - baseline.hempcreteBales, 'bales');
+
+  baselineCarbonTarget.textContent = `${formatDecimal(baseline.carbonCredits, 1)} credits`;
+  scenarioCarbonTarget.textContent = `${formatDecimal(scenario.carbonCredits, 1)} credits`;
+  deltaCarbonTarget.textContent = deltaLabel(scenario.carbonCredits - baseline.carbonCredits, 'credits', 1);
+
+  baselineReinvestmentTarget.textContent = formatCurrency(baseline.totalReinvestment);
+  scenarioReinvestmentTarget.textContent = formatCurrency(scenario.totalReinvestment);
+  deltaReinvestmentTarget.textContent = deltaCurrencyLabel(scenario.totalReinvestment - baseline.totalReinvestment);
+}
+
+function deltaLabel(value, unit, fractionDigits = 0) {
+  const formattedValue =
+    fractionDigits > 0 ? formatDecimal(Math.abs(value), fractionDigits) : formatNumber(Math.abs(value));
+  if (value === 0) {
+    return 'No change';
+  }
+  const prefix = value > 0 ? '+' : '−';
+  const unitLabel = unit ? ` ${unit}` : '';
+  return `${prefix}${formattedValue}${unitLabel}`;
+}
+
+function deltaCurrencyLabel(value) {
+  if (value === 0) {
+    return 'No change';
+  }
+  const prefix = value > 0 ? '+' : '−';
+  const absolute = Math.abs(value);
+  return `${prefix}${formatCurrency(absolute)}`;
+}
+
+if (membersSlider && panelsSlider) {
+  membersSlider.addEventListener('input', renderScenario);
+  panelsSlider.addEventListener('input', renderScenario);
+  renderScenario();
+}
+
+if (dashboardYear) {
+  dashboardYear.textContent = new Date().getFullYear().toString();
+}

--- a/public/index.html
+++ b/public/index.html
@@ -297,6 +297,10 @@
           Solar Roots turns underused rooftops into solar-fed gardens and stores stocked by the people who live nearby. Clean
           energy, zero food deserts.
         </p>
+        <p class="lede" style="font-size: 1rem; color: rgba(255, 255, 255, 0.78);">
+          Preview the cooperative impact in our new Solar Roots Dashboard prototype and see how quickly reinvestment grows when
+          neighbors build panels together.
+        </p>
       </div>
 
       <div class="hero-actions">
@@ -318,7 +322,8 @@
 
         <div class="hero-links">
           <strong>Next steps</strong>
-          <a class="primary-link" href="/learn-more.html">Learn more about Solar Roots <span aria-hidden="true">→</span></a>
+          <a class="primary-link" href="/dashboard.html">Explore the Solar Roots Dashboard <span aria-hidden="true">→</span></a>
+          <a class="secondary-link" href="/learn-more.html">Learn more about Solar Roots <span aria-hidden="true">→</span></a>
           <a class="secondary-link" href="/signup.html">Join the co-op<span aria-hidden="true"> →</span></a>
           <a class="secondary-link" href="/login.html">Member login<span aria-hidden="true"> →</span></a>
           <a class="secondary-link" href="/admin.html">Admin login<span aria-hidden="true"> →</span></a>


### PR DESCRIPTION
## Summary
- add a Solar Roots Dashboard page that visualizes mock cooperative energy, hempcrete, and reinvestment data with adjustable sliders
- surface the dashboard from the landing page and highlight the proof-of-concept messaging
- redirect successful admin logins to the dashboard for quick access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fc2d411ec88332b3aea8935441434f