### PR TITLE
Improve mobile responsiveness across public pages

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -26,7 +26,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 3rem 1.5rem;
+      padding: clamp(2.5rem, 8vw, 3rem) clamp(1.25rem, 6vw, 1.75rem);
       background: linear-gradient(160deg, rgba(46, 94, 78, 0.96), rgba(255, 216, 91, 0.35));
       color: #ffffff;
     }
@@ -139,6 +139,7 @@
       justify-content: center;
       gap: 1.25rem;
       font-weight: 600;
+      flex-wrap: wrap;
     }
 
     nav a {
@@ -153,12 +154,14 @@
     }
 
     @media (max-width: 520px) {
-      body {
-        padding: 2.5rem 1.25rem;
-      }
-
       main {
         padding: 2.25rem 1.75rem;
+      }
+
+      nav {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
       }
     }
   </style>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -36,6 +36,7 @@
       justify-content: space-between;
       align-items: center;
       gap: 1rem;
+      flex-wrap: wrap;
     }
 
     .brand {
@@ -286,6 +287,7 @@
       background: rgba(255, 216, 91, 0.12);
       padding: 0.75rem 1rem;
       border-radius: 14px;
+      gap: 0.35rem;
     }
 
     .fund-row span {
@@ -293,12 +295,18 @@
       letter-spacing: 0.05em;
     }
 
-    table {
-      width: 100%;
-      border-collapse: collapse;
+    .table-wrapper {
       background: rgba(0, 0, 0, 0.28);
       border-radius: 18px;
       overflow: hidden;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 520px;
     }
 
     thead {
@@ -329,14 +337,69 @@
     }
 
     @media (max-width: 720px) {
+      nav {
+        width: 100%;
+        justify-content: flex-start;
+      }
+    }
+
+    @media (max-width: 600px) {
       header {
+        padding: 1.5rem 1.25rem 0;
+        gap: 1.25rem;
+      }
+
+      .brand {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.65rem;
+      }
+
+      nav {
+        gap: 0.5rem;
+      }
+
+      nav a {
+        flex: 1 1 140px;
+        text-align: center;
+        min-width: 120px;
+      }
+
+      main {
+        padding: 2rem 1.25rem 3.25rem;
+      }
+
+      .impact-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .fund-row {
         flex-direction: column;
         align-items: flex-start;
       }
 
-      nav {
-        width: 100%;
-        justify-content: flex-start;
+      .fund-row span:last-child {
+        align-self: flex-end;
+      }
+    }
+
+    @media (max-width: 520px) {
+      .slider-label {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+
+      input[type="range"] {
+        height: 12px;
+      }
+
+      input[type="range"]::-webkit-slider-thumb,
+      input[type="range"]::-moz-range-thumb {
+        width: 22px;
+        height: 22px;
       }
     }
   </style>
@@ -453,42 +516,44 @@
 
     <section aria-labelledby="baseline-table-heading">
       <h2 id="baseline-table-heading" style="font-size: clamp(1.4rem, 3vw, 2rem); margin-bottom: 1.25rem;">Scenario vs. baseline snapshot</h2>
-      <table aria-describedby="baseline-note">
-        <thead>
-          <tr>
-            <th scope="col">Indicator</th>
-            <th scope="col">Baseline pilot</th>
-            <th scope="col">Your scenario</th>
-            <th scope="col">Change</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">Annual energy (kWh)</th>
-            <td id="baseline-energy">—</td>
-            <td id="scenario-energy">—</td>
-            <td id="delta-energy">—</td>
-          </tr>
-          <tr>
-            <th scope="row">Hempcrete bales</th>
-            <td id="baseline-hempcrete">—</td>
-            <td id="scenario-hempcrete">—</td>
-            <td id="delta-hempcrete">—</td>
-          </tr>
-          <tr>
-            <th scope="row">Carbon credits</th>
-            <td id="baseline-carbon">—</td>
-            <td id="scenario-carbon">—</td>
-            <td id="delta-carbon">—</td>
-          </tr>
-          <tr>
-            <th scope="row">Grocery fund ($)</th>
-            <td id="baseline-reinvestment">—</td>
-            <td id="scenario-reinvestment">—</td>
-            <td id="delta-reinvestment">—</td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-wrapper">
+        <table aria-describedby="baseline-note">
+          <thead>
+            <tr>
+              <th scope="col">Indicator</th>
+              <th scope="col">Baseline pilot</th>
+              <th scope="col">Your scenario</th>
+              <th scope="col">Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Annual energy (kWh)</th>
+              <td id="baseline-energy">—</td>
+              <td id="scenario-energy">—</td>
+              <td id="delta-energy">—</td>
+            </tr>
+            <tr>
+              <th scope="row">Hempcrete bales</th>
+              <td id="baseline-hempcrete">—</td>
+              <td id="scenario-hempcrete">—</td>
+              <td id="delta-hempcrete">—</td>
+            </tr>
+            <tr>
+              <th scope="row">Carbon credits</th>
+              <td id="baseline-carbon">—</td>
+              <td id="scenario-carbon">—</td>
+              <td id="delta-carbon">—</td>
+            </tr>
+            <tr>
+              <th scope="row">Grocery fund ($)</th>
+              <td id="baseline-reinvestment">—</td>
+              <td id="scenario-reinvestment">—</td>
+              <td id="delta-reinvestment">—</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <p id="baseline-note" style="margin-top: 1rem; font-size: 0.85rem; color: rgba(255, 255, 255, 0.7);">
         Baseline is anchored to an 8-block pilot with 100 member-owners and 180 panels feeding a 150 kW shared battery.
       </p>

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@
       justify-content: space-between;
       align-items: center;
       gap: 1rem;
+      flex-wrap: wrap;
     }
 
     .brand {
@@ -73,6 +74,7 @@
       border-radius: 999px;
       background: rgba(0, 0, 0, 0.18);
       transition: transform 0.2s ease, background 0.2s ease;
+      text-align: center;
     }
 
     .nav-link:hover,
@@ -186,6 +188,7 @@
       background: #ffd85b;
       color: #2e5e4e;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      width: 100%;
     }
 
     button[type="submit"]:hover,
@@ -262,10 +265,8 @@
       font-size: 0.9rem;
     }
 
-    @media (max-width: 640px) {
+    @media (max-width: 768px) {
       header {
-        flex-direction: column;
-        align-items: flex-start;
         gap: 1.25rem;
       }
 
@@ -275,6 +276,53 @@
 
       .hero-actions {
         grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 520px) {
+      body {
+        padding-bottom: 2rem;
+      }
+
+      header {
+        padding: 1.5rem 1.25rem 0;
+      }
+
+      .brand {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        justify-content: flex-start;
+      }
+
+      .nav-link {
+        width: 100%;
+        max-width: 320px;
+      }
+
+      main {
+        padding: 2rem 1.25rem 3rem;
+      }
+
+      .hero {
+        border-radius: 20px;
+        padding: 1.85rem 1.5rem;
+        gap: 1.75rem;
+      }
+
+      .hero-header {
+        gap: 0.85rem;
+      }
+
+      .hero-form {
+        padding: 1.5rem;
+      }
+
+      .primary-link,
+      .secondary-link {
+        justify-content: center;
+        width: 100%;
       }
     }
   </style>

--- a/public/learn-more.html
+++ b/public/learn-more.html
@@ -35,6 +35,7 @@
       justify-content: space-between;
       align-items: center;
       gap: 1.5rem;
+      flex-wrap: wrap;
     }
 
     .brand {
@@ -72,6 +73,7 @@
       border-radius: 999px;
       background: rgba(0, 0, 0, 0.18);
       transition: transform 0.2s ease, background 0.2s ease;
+      text-align: center;
     }
 
     .nav-link:hover,
@@ -173,20 +175,36 @@
       font-size: 0.9rem;
     }
 
-    @media (max-width: 640px) {
+    @media (max-width: 720px) {
       header {
-        flex-direction: column;
-        align-items: flex-start;
+        gap: 1.25rem;
+      }
+    }
+
+    @media (max-width: 560px) {
+      header {
+        padding: 1.75rem 1.25rem;
       }
 
-      .lede {
-        text-align: left;
+      .brand {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.65rem;
       }
 
-      .section-header {
-        text-align: left;
+      .nav-link {
+        width: 100%;
+        max-width: 320px;
       }
 
+      main {
+        padding: 2rem 1.25rem 3rem;
+      }
+
+      .section-header,
+      .lede,
       h2 {
         text-align: left;
       }

--- a/public/login.html
+++ b/public/login.html
@@ -26,7 +26,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 3rem 1.5rem;
+      padding: clamp(2.5rem, 8vw, 3rem) clamp(1.25rem, 6vw, 1.75rem);
       background: linear-gradient(to bottom right, rgba(46, 94, 78, 0.95), rgba(255, 216, 91, 0.85));
       color: #ffffff;
     }
@@ -146,6 +146,7 @@
       justify-content: center;
       gap: 1.5rem;
       font-weight: 600;
+      flex-wrap: wrap;
     }
 
     .nav-links a {
@@ -160,12 +161,14 @@
     }
 
     @media (max-width: 520px) {
-      body {
-        padding: 2.5rem 1.25rem;
-      }
-
       main {
         padding: 2rem 1.5rem;
+      }
+
+      .nav-links {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
       }
     }
   </style>

--- a/public/signup.html
+++ b/public/signup.html
@@ -26,7 +26,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 3rem 1.5rem;
+      padding: clamp(2.5rem, 8vw, 3.25rem) clamp(1.25rem, 6vw, 1.75rem);
       background: linear-gradient(to bottom right, rgba(46, 94, 78, 0.95), rgba(255, 216, 91, 0.85));
       color: #ffffff;
     }
@@ -117,6 +117,7 @@
       background: #2e5e4e;
       color: #ffd85b;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      width: 100%;
     }
 
     button[type="submit"]:hover,
@@ -144,6 +145,7 @@
       justify-content: center;
       gap: 1.5rem;
       font-weight: 600;
+      flex-wrap: wrap;
     }
 
     .nav-links a {
@@ -158,12 +160,14 @@
     }
 
     @media (max-width: 520px) {
-      body {
-        padding: 2.5rem 1.25rem;
-      }
-
       main {
         padding: 2rem 1.5rem;
+      }
+
+      .nav-links {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- tune the landing and learn pages so headers, links, and hero content reflow cleanly on narrow screens
- update dashboard layouts with mobile-friendly nav spacing, slider ergonomics, and a scrollable metrics table wrapper
- refine auth and admin forms with responsive padding, wrapping navigation, and full-width buttons

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fc2fa4692c8332a424ef7e78210f51